### PR TITLE
Procedural improvements

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -369,7 +369,6 @@ class RecorderGui(customtkinter.CTk):
         )
         if str(self.deCheck.get()) == "off":
             self.file_name = f"{self.manualDate.get()}-{self.manualEvent.get()}"
-            self.manualEvent.set(f"{event_type()}")
         self.engine.sa_status = self.sa_status
         self.engine.file_name = f"{self.file_name}"
         self.engine.is_recording = False

--- a/gui.py
+++ b/gui.py
@@ -346,6 +346,8 @@ class RecorderGui(customtkinter.CTk):
     # Functions
     def recording(self):
         self.settings_gui_button.configure(state="disabled")
+        if str(self.deCheck.get()) == "on":
+            self.manualEvent.set(f"{event_type()}")
         self.write_console("[ServiceRecorder] Settings disabled while recording.")
         self.file_name = f"{fullDateStamp}-{self.manualEvent.get()}"
         self.engine.is_recording = True

--- a/gui.py
+++ b/gui.py
@@ -367,6 +367,7 @@ class RecorderGui(customtkinter.CTk):
         )
         if str(self.deCheck.get()) == "off":
             self.file_name = f"{self.manualDate.get()}-{self.manualEvent.get()}"
+            self.manualEvent.set(f"{event_type()}")
         self.engine.sa_status = self.sa_status
         self.engine.file_name = f"{self.file_name}"
         self.engine.is_recording = False
@@ -380,12 +381,17 @@ class RecorderGui(customtkinter.CTk):
         self.engine.event_type = f"{self.manualEvent.get()}"
         if self.sa_upload.get() == 1:
             self.engine.sa_upload = f"{self.sa_upload.get()}"
+        self.sermonField.delete(0, "end")
+        self.speakerField.delete(0, "end")
+        self.refField.delete(0, "end")
+        self.seriesField.set("")
         self.settings_gui_button.configure(state="normal")
 
     def set_date_event(self):
         self.manualEvent.configure(
             state="normal" if str(self.deCheck.get()) == "off" else "disabled"
         )
+        self.manualEvent.set(f"{event_type()}")
         self.manualDate.configure(
             state="normal" if str(self.deCheck.get()) == "off" else "disabled"
         )


### PR DESCRIPTION
Changes:

- When enabling "Automatically Set Date/Event", the event is updated based on the current time
- If "Automatically Set Date/Event" is selected, the event type is re-evaluated when the recording is started
- After recording is done and handed off to the audio engine, the metadata fields are cleared for the next recording